### PR TITLE
[feature] WaveProgressBar

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './color'
 export * from './print'
 export * from './prompt'
+export * from './progressBar'
 

--- a/src/utils/progressBar.ts
+++ b/src/utils/progressBar.ts
@@ -1,0 +1,47 @@
+export class WaveProgressBar {
+    readonly DEFAULT_CHAR: string = '=';
+    readonly EMPTY_CHAR: string = ' ';
+
+    progress: number = 0;
+    max: number;
+    step: number;
+    char: string;
+
+    constructor(max: number = 100, step: number = 1, char?: string) {
+        this.max = max;
+        this.step = step;
+        this.char = char ?? this.DEFAULT_CHAR;
+    }
+
+    init() {
+        this.progress = 0;
+        this.render();
+    }
+
+    advance() {
+        if (this.progress + this.step <= this.max) {
+            this.progress += this.step;
+        } else {
+            this.progress = this.max;
+        }
+
+        this.render();
+    }
+
+    finish() {
+        this.progress = this.max;
+        this.render();
+        process.stdout.write("\n");
+    }
+
+    private render() {
+        const progress = this.char.repeat(this.progress);
+        const empty = this.EMPTY_CHAR.repeat(this.max - this.progress);
+        const percent = ((this.progress / this.max) * 100).toFixed(2) + '%';
+        const rendered = `[${progress}${empty}] ${percent}`;
+
+        process.stdout.clearLine(-1)
+        process.stdout.cursorTo(0);
+        process.stdout.write('\r' + rendered);
+    }
+}


### PR DESCRIPTION
Several large CLI libraries include an easy way to create progress bars, with this in mind I brought a new class to Wave, the WaveProgressBar.

To instantiate a new WaveProgressBar, we have a 3 params:
- `max`: the number max of progress, default is `100`;
- `step`: amount that will advance with each step;
- `char`: the char will be rendered in progress bar;

The WaveProgressBar has 3 main methods:
- `init`: display the progress bar in the stdout;
- `advance`: increment the progress bar based on the step defined in the constructor;
- `finish`: set the progress to max and render the final progress;


Example of usage:
```ts
import { WaveCommand, WaveProgressBar } from "wave-shell";

function wait(ms: number) {
    return new Promise(resolve => setTimeout(resolve, ms));
}

export default {
    description: 'Running a progress bar',
    async run() {
        let progressBar = new WaveProgressBar(100, 5, '#');

        progressBar.init();

        for (let i = 0; i < 10; i++) {
            progressBar.advance();
            await wait(100);
        }

        progressBar.finish();
    },
} as WaveCommand
```

I am available for any necessary changes :smiley: 